### PR TITLE
feat: 检测并送葬 state:failed 僵死 daemon job + 只读存活探测 (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Claude Code 的菜单栏会话管理器**——常驻菜单栏，一键启动、切换、恢复、搜索、命名会话。
 
-> **安全声明**：Forge Launcher 只在 Claude Code 官方 CLI 和文件接口上做 UI 层。不修改 Claude Code 的源代码、不改动会话 JSONL 文件、不接触 Claude Code 内部状态。启动器自己的数据（名字、置顶）存在独立文件里，和 Claude Code 的数据完全隔离。写入/删除 CC 文件只有两个场景，都需用户手动点击才触发：① [竞态修复](#已知问题)（修复 CC 自己写错的 PID 追踪文件）；② 清理僵死任务（删除 `state:failed` 的 daemon job 的**可见残留目录** `~/.claude/jobs/<id>/`，双重确认；只动不可恢复的 failed job，绝不碰 blocked 等存活态。注：仅删目录残留，不终止底层 daemon 进程——彻底终止用 `claude agents`）。
+> **安全声明**：Forge Launcher 只在 Claude Code 官方 CLI 和文件接口上做 UI 层。不修改 Claude Code 的源代码、不改动会话 JSONL 文件、不接触 Claude Code 内部状态。启动器自己的数据（名字、置顶）存在独立文件里，和 Claude Code 的数据完全隔离。写入/删除 CC 文件只有两个场景，都需用户手动点击才触发：① [竞态修复](#已知问题)（修复 CC 自己写错的 PID 追踪文件）；② 处理僵死任务（`state:failed` 的 daemon job，按存活探测分两路）：进程仍在的 → ⏹ `claude stop` 终止进程**但保留对话**（可 `claude attach` 恢复，不删目录）；已死的尸体 → 🗑 删除残留目录 `~/.claude/jobs/<id>/`（不可恢复，二次确认）。均需用户手动点击触发，绝不碰 `blocked` 等存活态。
 
 * **会话列表** — 按日期分组（今天/昨天/4月20日…），活跃会话绿色标记
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Claude Code 的菜单栏会话管理器**——常驻菜单栏，一键启动、切换、恢复、搜索、命名会话。
 
-> **安全声明**：Forge Launcher 只在 Claude Code 官方 CLI 和文件接口上做 UI 层。不修改 Claude Code 的源代码、不改动会话 JSONL 文件、不接触 Claude Code 内部状态。启动器自己的数据（名字、置顶）存在独立文件里，和 Claude Code 的数据完全隔离。唯一写入 CC 文件的场景是[竞态修复](#已知问题)（用户手动点击才触发，修复的是 CC 自己写错的 PID 追踪文件）。
+> **安全声明**：Forge Launcher 只在 Claude Code 官方 CLI 和文件接口上做 UI 层。不修改 Claude Code 的源代码、不改动会话 JSONL 文件、不接触 Claude Code 内部状态。启动器自己的数据（名字、置顶）存在独立文件里，和 Claude Code 的数据完全隔离。写入/删除 CC 文件只有两个场景，都需用户手动点击才触发：① [竞态修复](#已知问题)（修复 CC 自己写错的 PID 追踪文件）；② 清理僵死任务（删除 `state:failed` 的 daemon job 的**可见残留目录** `~/.claude/jobs/<id>/`，双重确认；只动不可恢复的 failed job，绝不碰 blocked 等存活态。注：仅删目录残留，不终止底层 daemon 进程——彻底终止用 `claude agents`）。
 
 * **会话列表** — 按日期分组（今天/昨天/4月20日…），活跃会话绿色标记
 

--- a/menubar/AppDelegate.swift
+++ b/menubar/AppDelegate.swift
@@ -55,6 +55,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             self?.hub?.resumeChannel(sid)
         }
         popoverCtrl.onRepair = { [weak self] in self?.repairStaleSessions() }
+        popoverCtrl.onPurgeJobs = { [weak self] in self?.purgeFailedJobs() }
         popoverCtrl.onRefresh = { [weak self] in self?.scanAndSync() }
         popoverCtrl.onSettings = { [weak self] in self?.showSettings() }
         popoverCtrl.onQuit = { NSApplication.shared.terminate(nil) }
@@ -151,6 +152,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         popoverCtrl.activeSIDs = scanner.activeSIDs
         popoverCtrl.starredSIDs = store.stars
         popoverCtrl.staleCount = scanner.staleSessions.count
+        popoverCtrl.failedJobCount = scanner.failedJobs.count
         popoverCtrl.hubTags = scanner.hubTags
         popoverCtrl.hubDescs = scanner.hubDescs
         popoverCtrl.sessionDescs = descStore.snapshot()
@@ -405,6 +407,84 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             let newAuth = authCheck.state == .on
             if newAuth != config.authCheckEnabled { config.setAuthCheckEnabled(newAuth) }
         }
+    }
+
+    /// 清理 state=="failed" 僵死 daemon job 的**可见残留目录**（~/.claude/jobs/<id>/）。
+    /// 送葬前先跑只读存活探测（claude agents --json），把每条标成 进程仍在/残留可清/状态未知，
+    /// 双重确认 + 列出将删的 job 名/摘要。只动 scanner.scanFailedJobs() 收的 failed job
+    /// （blocked/done/活 session 已在扫描层排除）。是继 repairStaleSessions 之后第二个用户手动触发才写 CC 文件的场景。
+    ///
+    /// ⚠️ 范围边界：只删 jobs/<id>/ 目录，不终止底层 daemon 进程。完整 teardown（确认进程真死 +
+    /// 释放）属 oracle 线（#8/#12 §B），不在本功能范围——只负责清掉可见的目录残留。
+    func purgeFailedJobs() {
+        popover.performClose(nil)
+        let jobs = scanner.failedJobs
+        if jobs.isEmpty { return }
+
+        // 只读存活探测放后台跑（claude agents 子进程最长 timeout，不冻结 UI）。
+        // 护栏（降级）：probe 只影响对话框措辞；删除动作绝不依赖它——nil 也照常能删。
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let liveIds = self?.scanner.liveAgentSessionIds()
+            DispatchQueue.main.async {
+                self?.presentPurgeConfirmation(jobs: jobs, liveSessionIds: liveIds)
+            }
+        }
+    }
+
+    /// 弹双确认框并执行删除。措辞随只读探测结果动态：
+    /// live（进程仍在）→ ⚠ 留孤儿提示；dead（不在 live 列表）→ 残留可清；
+    /// liveSessionIds==nil（探测不可用）→ 降级回静态范围边界文案。
+    private func presentPurgeConfirmation(jobs: [FailedJob], liveSessionIds: Set<String>?) {
+        let liveness = jobs.map { SessionScanner.jobLiveness(sessionId: $0.sessionId, liveSessionIds: liveSessionIds) }
+        let liveCount = liveness.filter { $0 == .live }.count
+        let probeAvailable = liveSessionIds != nil
+
+        let listing = zip(jobs, liveness).map { (job, live) -> String in
+            let mark: String
+            switch live {
+            case .live:    mark = "  ⚠ 进程仍在运行"
+            case .dead:    mark = "  ✓ 残留可清"
+            case .unknown: mark = ""
+            }
+            let detail = job.detail.isEmpty ? "" : "\n    \(job.detail.prefix(80))"
+            return "• \(job.name)  [\(job.jobId)]\(mark)\(detail)"
+        }.joined(separator: "\n")
+
+        // 第一确认：摘要 + 列表（含每条的存活标注）
+        let first = NSAlert()
+        first.messageText = "清理 \(jobs.count) 个僵死任务？"
+        first.informativeText = "以下 daemon job 处于 state:failed，将删除其 ~/.claude/jobs/<id>/ 目录：\n\n\(listing)"
+        first.alertStyle = .warning
+        first.addButton(withTitle: "取消")   // 默认（Return）= 安全
+        first.addButton(withTitle: "清理…")
+        guard first.runModal() == .alertSecondButtonReturn else { return }
+
+        // 第二确认：不可恢复 + 范围边界（措辞随探测结果）
+        let boundary: String
+        if liveCount > 0 {
+            boundary = "⚠ 其中 \(liveCount) 个进程仍在 live 列表：删目录不会停止它们，只会留下孤儿。彻底停用请走 `claude agents`。"
+        } else if probeAvailable {
+            boundary = "已核对 claude agents：这些 session 都不在 live 列表，删目录是安全的残留清理。"
+        } else {
+            boundary = "注意：未能核对进程存活（claude agents 不可用）。删的只是 jobs/<id>/ 目录；若进程仍在运行，彻底停用 `claude agents`。"
+        }
+        let second = NSAlert()
+        second.messageText = "确认删除这 \(jobs.count) 个任务目录？"
+        second.informativeText = "此操作不可恢复，删除的是 ~/.claude/jobs/<id>/ 目录（可见残留）。\n\n\(boundary)"
+        second.alertStyle = .critical
+        second.addButton(withTitle: "取消")   // 默认（Return）= 安全
+        second.addButton(withTitle: "删除（不可恢复）")
+        guard second.runModal() == .alertSecondButtonReturn else { return }
+
+        for job in jobs {
+            do {
+                try FileManager.default.removeItem(at: job.dir)
+            } catch {
+                os_log("purgeFailedJobs remove failed (%{public}@): %{public}@",
+                       log: log, type: .error, job.jobId, error.localizedDescription)
+            }
+        }
+        scanAndSync()
     }
 
     func showChooseDialog(title: String, prompt: String, items: [String]) -> Int? {

--- a/menubar/AppDelegate.swift
+++ b/menubar/AppDelegate.swift
@@ -409,79 +409,109 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
     }
 
-    /// 清理 state=="failed" 僵死 daemon job 的**可见残留目录**（~/.claude/jobs/<id>/）。
-    /// 送葬前先跑只读存活探测（claude agents --json），把每条标成 进程仍在/残留可清/状态未知，
-    /// 双重确认 + 列出将删的 job 名/摘要。只动 scanner.scanFailedJobs() 收的 failed job
-    /// （blocked/done/活 session 已在扫描层排除）。是继 repairStaleSessions 之后第二个用户手动触发才写 CC 文件的场景。
-    ///
-    /// ⚠️ 范围边界：只删 jobs/<id>/ 目录，不终止底层 daemon 进程。完整 teardown（确认进程真死 +
-    /// 释放）属 oracle 线（#8/#12 §B），不在本功能范围——只负责清掉可见的目录残留。
+    /// 处理 state=="failed" 僵死 daemon job。送葬前跑只读存活探测（claude agents --json），
+    /// 按诊断**分两条路**（用户手动点红条触发，是继 repairStaleSessions 之后第二个写/删 CC 文件的场景）：
+    ///  - **live**（failed + sessionId 仍在 agents 列表）= 进程还活、有对话有工作，没真死
+    ///    → ⏹ `claude stop <jobId>`：终止进程**但保留对话**（可 `claude attach` 恢复），**不删目录**。
+    ///      实测停后 state → "stopped"，自动掉出 state=="failed" 红条，不会被再当尸体催删。
+    ///  - **dead**（failed + 不在 agents 列表）= 进程已亡、无可恢复 = 真坏的尸体
+    ///    → 🗑 removeItem 删 ~/.claude/jobs/<id>/（不可恢复）。
+    ///  - **unknown**：probe 不可用（liveSessionIds==nil）→ 保守退回「带警告的纯删」；
+    ///    probe 可用但该 job 缺 sessionId → 跳过，不自动选破坏动作。
     func purgeFailedJobs() {
         popover.performClose(nil)
         let jobs = scanner.failedJobs
         if jobs.isEmpty { return }
 
         // 只读存活探测放后台跑（claude agents 子进程最长 timeout，不冻结 UI）。
-        // 护栏（降级）：probe 只影响对话框措辞；删除动作绝不依赖它——nil 也照常能删。
+        // 护栏（降级）：probe nil → unknown → 不自动选破坏动作（见 presentPurgeFlow）。
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             let liveIds = self?.scanner.liveAgentSessionIds()
             DispatchQueue.main.async {
-                self?.presentPurgeConfirmation(jobs: jobs, liveSessionIds: liveIds)
+                self?.presentPurgeFlow(jobs: jobs, liveSessionIds: liveIds)
             }
         }
     }
 
-    /// 弹双确认框并执行删除。措辞随只读探测结果动态：
-    /// live（进程仍在）→ ⚠ 留孤儿提示；dead（不在 live 列表）→ 残留可清；
-    /// liveSessionIds==nil（探测不可用）→ 降级回静态范围边界文案。
-    private func presentPurgeConfirmation(jobs: [FailedJob], liveSessionIds: Set<String>?) {
-        let liveness = jobs.map { SessionScanner.jobLiveness(sessionId: $0.sessionId, liveSessionIds: liveSessionIds) }
-        let liveCount = liveness.filter { $0 == .live }.count
-        let probeAvailable = liveSessionIds != nil
-
-        let listing = zip(jobs, liveness).map { (job, live) -> String in
-            let mark: String
-            switch live {
-            case .live:    mark = "  ⚠ 进程仍在运行"
-            case .dead:    mark = "  ✓ 残留可清"
-            case .unknown: mark = ""
-            }
-            let detail = job.detail.isEmpty ? "" : "\n    \(job.detail.prefix(80))"
-            return "• \(job.name)  [\(job.jobId)]\(mark)\(detail)"
-        }.joined(separator: "\n")
-
-        // 第一确认：摘要 + 列表（含每条的存活标注）
-        let first = NSAlert()
-        first.messageText = "清理 \(jobs.count) 个僵死任务？"
-        first.informativeText = "以下 daemon job 处于 state:failed，将删除其 ~/.claude/jobs/<id>/ 目录：\n\n\(listing)"
-        first.alertStyle = .warning
-        first.addButton(withTitle: "取消")   // 默认（Return）= 安全
-        first.addButton(withTitle: "清理…")
-        guard first.runModal() == .alertSecondButtonReturn else { return }
-
-        // 第二确认：不可恢复 + 范围边界（措辞随探测结果）
-        let boundary: String
-        if liveCount > 0 {
-            boundary = "⚠ 其中 \(liveCount) 个进程仍在 live 列表：删目录不会停止它们，只会留下孤儿。彻底停用请走 `claude agents`。"
-        } else if probeAvailable {
-            boundary = "已核对 claude agents：这些 session 都不在 live 列表，删目录是安全的残留清理。"
-        } else {
-            boundary = "注意：未能核对进程存活（claude agents 不可用）。删的只是 jobs/<id>/ 目录；若进程仍在运行，彻底停用 `claude agents`。"
-        }
-        let second = NSAlert()
-        second.messageText = "确认删除这 \(jobs.count) 个任务目录？"
-        second.informativeText = "此操作不可恢复，删除的是 ~/.claude/jobs/<id>/ 目录（可见残留）。\n\n\(boundary)"
-        second.alertStyle = .critical
-        second.addButton(withTitle: "取消")   // 默认（Return）= 安全
-        second.addButton(withTitle: "删除（不可恢复）")
-        guard second.runModal() == .alertSecondButtonReturn else { return }
-
+    /// 按 probe 诊断把 jobs 分成 停用/删除/跳过 三桶，弹 overview 确认，继续后：
+    /// 后台跑 claude stop（不冻结 UI）→ 回主线程报告停用失败 + 对删除做不可恢复二次确认。
+    private func presentPurgeFlow(jobs: [FailedJob], liveSessionIds: Set<String>?) {
+        let probeDown = (liveSessionIds == nil)
+        var stopTargets: [FailedJob] = [], deleteTargets: [FailedJob] = [], skipTargets: [FailedJob] = []
         for job in jobs {
-            do {
-                try FileManager.default.removeItem(at: job.dir)
-            } catch {
-                os_log("purgeFailedJobs remove failed (%{public}@): %{public}@",
-                       log: log, type: .error, job.jobId, error.localizedDescription)
+            switch SessionScanner.jobLiveness(sessionId: job.sessionId, liveSessionIds: liveSessionIds) {
+            case .live:    stopTargets.append(job)
+            case .dead:    deleteTargets.append(job)
+            case .unknown: probeDown ? deleteTargets.append(job) : skipTargets.append(job)
+            }
+        }
+
+        func line(_ j: FailedJob, _ kind: String) -> String {
+            let d = j.detail.isEmpty ? "" : "\n    \(j.detail.prefix(70))"
+            return "\(kind) \(j.name)  [\(j.jobId)]\(d)"
+        }
+        var lines: [String] = []
+        lines += stopTargets.map { line($0, "⏹ 停用(保留对话)") }
+        lines += deleteTargets.map { line($0, "🗑 删除(不可恢复)") }
+        lines += skipTargets.map { line($0, "⏭ 跳过(状态未知)") }
+
+        let overview = NSAlert()
+        overview.messageText = "处理 \(jobs.count) 个僵死任务"
+        var info = ""
+        if probeDown { info += "⚠ 未能核对进程存活（claude agents 不可用），以下按「删除残留」保守处理。\n\n" }
+        info += "继续将执行：\n" + lines.joined(separator: "\n")
+        if !stopTargets.isEmpty {
+            info += "\n\n⏹ 停用 = `claude stop`：终止进程但保留对话，可 `claude attach` 恢复，不删目录。"
+        }
+        overview.informativeText = info
+        overview.alertStyle = .warning
+        overview.addButton(withTitle: "取消")   // 默认（Return）= 安全
+        overview.addButton(withTitle: "继续")
+        guard overview.runModal() == .alertSecondButtonReturn else { return }
+
+        // 停用（claude stop 子进程）放后台跑，不冻结 UI；完了回主线程报告 + 做删除二次确认。
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+            var stopFailed: [FailedJob] = []
+            for job in stopTargets {
+                if !self.scanner.stopAgentSession(jobId: job.jobId, sessionId: job.sessionId) {
+                    stopFailed.append(job)   // 不假装停了
+                }
+            }
+            DispatchQueue.main.async {
+                self.finishPurge(deleteTargets: deleteTargets, stopFailed: stopFailed)
+            }
+        }
+    }
+
+    /// 报告 claude stop 失败（不静默吞）+ 对「删除残留」做不可恢复的二次确认。
+    private func finishPurge(deleteTargets: [FailedJob], stopFailed: [FailedJob]) {
+        if !stopFailed.isEmpty {
+            let a = NSAlert()
+            a.messageText = "⏹ \(stopFailed.count) 个停用未确认成功"
+            a.informativeText = "claude stop 未确认这些已停（退出码非 0 或仍在 agents 列表），未动它们的目录：\n"
+                + stopFailed.map { "• \($0.name) [\($0.jobId)]" }.joined(separator: "\n")
+                + "\n\n可手动 `claude stop <id>`，或 `claude agents` 查看。"
+            a.alertStyle = .warning
+            a.runModal()
+        }
+        if !deleteTargets.isEmpty {
+            let del = NSAlert()
+            del.messageText = "🗑 删除 \(deleteTargets.count) 个残留目录？"
+            del.informativeText = "此操作不可恢复，删除 ~/.claude/jobs/<id>/（仅死掉的尸体，不影响其他会话）：\n"
+                + deleteTargets.map { "• \($0.name) [\($0.jobId)]" }.joined(separator: "\n")
+            del.alertStyle = .critical
+            del.addButton(withTitle: "取消")   // 默认（Return）= 安全
+            del.addButton(withTitle: "删除（不可恢复）")
+            if del.runModal() == .alertSecondButtonReturn {
+                for job in deleteTargets {
+                    do {
+                        try FileManager.default.removeItem(at: job.dir)
+                    } catch {
+                        os_log("purge remove failed (%{public}@): %{public}@",
+                               log: log, type: .error, job.jobId, error.localizedDescription)
+                    }
+                }
             }
         }
         scanAndSync()

--- a/menubar/Models.swift
+++ b/menubar/Models.swift
@@ -20,3 +20,23 @@ struct StaleSession {
     let staleSID: String
     let startedAt: TimeInterval
 }
+
+/// 一个 ~/.claude/jobs/<id>/ 下 state=="failed" 的僵死 daemon job。
+/// 只收 state=="failed"——blocked（bg session 等输入的存活态）/ done / 运行中都不算（见 SessionScanner.scanFailedJobs）。
+struct FailedJob {
+    let jobId: String     // jobs/ 下的目录名
+    let dir: URL          // ~/.claude/jobs/<jobId>/
+    let name: String      // state.json 的 name（人看的标题），缺省 jobId
+    let detail: String    // state.json 的 detail/intent 摘要，给确认对话框展示
+    let sessionId: String // state.json 的 sessionId（完整 UUID），与 claude agents --json 的 sessionId 对齐，供只读存活探测
+}
+
+/// 送葬前对一个 failed job 的存活判定（基于 claude agents --json 只读探测）。
+/// live：sessionId 仍在 live agents 列表 → 删目录会留孤儿，应走 `claude agents` 彻底停。
+/// dead：不在 live 列表 → 残留可清，删目录安全。
+/// unknown：探测不可用（claude 没找到/超时/解析失败）→ 降级，不对该 job 下存活断言。
+enum JobLiveness {
+    case live
+    case dead
+    case unknown
+}

--- a/menubar/PopoverController.swift
+++ b/menubar/PopoverController.swift
@@ -6,6 +6,8 @@ class SessionPopoverController: NSViewController, NSSearchFieldDelegate, NSTextF
     private var tableView: NSTableView!
     private var warningButton: NSButton!
     private var warningHeight: NSLayoutConstraint!
+    private var jobsWarningButton: NSButton!
+    private var jobsWarningHeight: NSLayoutConstraint!
     private var countLabel: NSTextField!
     private var refreshBtn: NSButton!
     private var channelBtn: NSButton!
@@ -14,6 +16,7 @@ class SessionPopoverController: NSViewController, NSSearchFieldDelegate, NSTextF
     var activeSIDs: Set<String> = []
     var starredSIDs: Set<String> = []
     var staleCount = 0
+    var failedJobCount = 0
     var hubTags: [String: String] = [:]   // keyed by session ID prefix (8 chars), Hub 兼容 fallback
     var hubDescs: [String: String] = [:]  // keyed by session ID prefix (8 chars), Hub 兼容 fallback
     var sessionDescs: [String: SessionDescription] = [:]  // keyed by FULL sessionId (UUID)——启动器 own 的权威
@@ -30,6 +33,7 @@ class SessionPopoverController: NSViewController, NSSearchFieldDelegate, NSTextF
     var onResumeChannel: ((String) -> Void)?
     var onStar: ((String) -> Void)?
     var onRepair: (() -> Void)?
+    var onPurgeJobs: (() -> Void)?
     var onRefresh: (() -> Void)?
     var onQuit: (() -> Void)?
     var onViewAll: (() -> Void)?
@@ -62,6 +66,14 @@ class SessionPopoverController: NSViewController, NSSearchFieldDelegate, NSTextF
         warningButton.isHidden = true
         warningButton.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(warningButton)
+
+        // Failed-job warning (hidden when no failed daemon job) — 镜像 stale 警告
+        jobsWarningButton = NSButton(title: "", target: self, action: #selector(doPurgeJobs))
+        jobsWarningButton.isBordered = false
+        jobsWarningButton.alignment = .left
+        jobsWarningButton.isHidden = true
+        jobsWarningButton.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(jobsWarningButton)
 
         tableView = NSTableView()
         tableView.delegate = self
@@ -106,6 +118,7 @@ class SessionPopoverController: NSViewController, NSSearchFieldDelegate, NSTextF
         container.addSubview(bottomBar)
 
         warningHeight = warningButton.heightAnchor.constraint(equalToConstant: 0)
+        jobsWarningHeight = jobsWarningButton.heightAnchor.constraint(equalToConstant: 0)
 
         NSLayoutConstraint.activate([
             searchField.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
@@ -120,7 +133,12 @@ class SessionPopoverController: NSViewController, NSSearchFieldDelegate, NSTextF
             warningButton.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -12),
             warningHeight,
 
-            scrollView.topAnchor.constraint(equalTo: warningButton.bottomAnchor, constant: 4),
+            jobsWarningButton.topAnchor.constraint(equalTo: warningButton.bottomAnchor),
+            jobsWarningButton.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 12),
+            jobsWarningButton.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -12),
+            jobsWarningHeight,
+
+            scrollView.topAnchor.constraint(equalTo: jobsWarningButton.bottomAnchor, constant: 4),
             scrollView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: bottomBar.topAnchor, constant: -4),
@@ -166,6 +184,21 @@ class SessionPopoverController: NSViewController, NSSearchFieldDelegate, NSTextF
         } else {
             warningButton.isHidden = true
             warningHeight.constant = 0
+        }
+
+        if failedJobCount > 0 {
+            jobsWarningButton.isHidden = false
+            jobsWarningHeight.constant = 22
+            jobsWarningButton.attributedTitle = NSAttributedString(
+                string: "🪦 \(failedJobCount) 个僵死任务（state:failed）— 点击清理",
+                attributes: [
+                    .font: NSFont.systemFont(ofSize: 12, weight: .medium),
+                    .foregroundColor: NSColor.systemRed,
+                ]
+            )
+        } else {
+            jobsWarningButton.isHidden = true
+            jobsWarningHeight.constant = 0
         }
 
         // 📡 通道会话按钮降级：
@@ -465,6 +498,7 @@ class SessionPopoverController: NSViewController, NSSearchFieldDelegate, NSTextF
     @objc func doNew() { onNew?() }
     @objc func doNewChannel() { onNewChannel?() }
     @objc func doRepair() { onRepair?() }
+    @objc func doPurgeJobs() { onPurgeJobs?() }
     @objc func doRefresh() {
         refreshBtn.title = "刷新中..."
         refreshBtn.isEnabled = false

--- a/menubar/SessionScanner.swift
+++ b/menubar/SessionScanner.swift
@@ -8,6 +8,7 @@ final class SessionScanner {
     private(set) var activeSIDs: Set<String> = []
     private(set) var sessionPIDMap: [String: Int] = [:]
     private(set) var staleSessions: [StaleSession] = []
+    private(set) var failedJobs: [FailedJob] = []
     var hubTags: [String: String] = [:]
     var hubDescs: [String: String] = [:]
     private(set) var isScanning = false
@@ -84,6 +85,98 @@ final class SessionScanner {
         onEnrich?()
     }
 
+    // MARK: - Failed Job Detection
+
+    /// 扫 ~/.claude/jobs/<id>/state.json,只收 state=="failed" 的僵死 daemon job。
+    ///
+    /// ⚠️ predicate 严格只匹配 "failed"。实测 v2.1.154 的 state 词表含 done / blocked /
+    /// failed: blocked 是 bg session 等待输入的存活态(daemon 还活着,只是 idle 等人),
+    /// 误删 blocked job 的目录 = 干掉一个活 session 的足迹。done = 正常完成。
+    /// 都不能进送葬清单。只有 failed(daemon 反复 --resume 死循环、不可恢复)才是真僵死。
+    func scanFailedJobs() {
+        failedJobs = []
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let jobsDir = home.appendingPathComponent(".claude/jobs")
+        guard let dirs = try? FileManager.default.contentsOfDirectory(
+            at: jobsDir, includingPropertiesForKeys: nil, options: .skipsHiddenFiles
+        ) else { return }
+
+        for dir in dirs {
+            var isDir: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: dir.path, isDirectory: &isDir), isDir.boolValue else { continue }
+            let stateFile = dir.appendingPathComponent("state.json")
+            guard let data = try? Data(contentsOf: stateFile),
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let state = obj["state"] as? String,
+                  state == "failed" else { continue }
+
+            let jobId = dir.lastPathComponent
+            let name = (obj["name"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? jobId
+            let rawDetail = (obj["detail"] as? String) ?? (obj["intent"] as? String) ?? ""
+            let detail = String(rawDetail.prefix(200))
+            let sessionId = (obj["sessionId"] as? String) ?? ""
+            failedJobs.append(FailedJob(jobId: jobId, dir: dir, name: name, detail: detail, sessionId: sessionId))
+        }
+    }
+
+    // MARK: - Live Agent Probe（只读 oracle · #11/#12 §B 方向）
+
+    /// 只读探测：跑 `claude agents --json` 取当前 live session 的 sessionId 集合。
+    ///
+    /// 这是 launcher 第一处、也是唯一一处 claude agents 依赖，方向对齐 #12 oracle，
+    /// 但**只读、只在送葬前用一次**，不进周期扫描、不扩散成全局 liveness 改造（那是 §B 产品决定）。
+    ///
+    /// 返回 nil = 探测不可用（claude 没找到 / 超时 / 非零退出 / 解析失败）。
+    /// ⚠️ 调用方必须把 nil 当"未知"优雅降级——**绝不能当成"没有 live session"**（那会误判活 job 可删）。
+    /// 实测：state.json 的 state 会滞后于真实存活（done 的 job 进程可能还 busy），故 agents 列表
+    /// 才是权威 liveness 信号。
+    func liveAgentSessionIds(timeout: TimeInterval = 3.0) -> Set<String>? {
+        let process = Process()
+        // 用 /usr/bin/env + PATH 增强解析 claude（GUI app 无 shell PATH，复用 augmentedEnvironment）
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["claude", "agents", "--json"]
+        process.environment = augmentedEnvironment()
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do { try process.run() } catch { return nil }
+
+        // 超时护栏：后台读管道，主等待超时则 terminate 并降级
+        let group = DispatchGroup()
+        group.enter()
+        var data = Data()
+        DispatchQueue.global(qos: .userInitiated).async {
+            data = pipe.fileHandleForReading.readDataToEndOfFile()
+            group.leave()
+        }
+        if group.wait(timeout: .now() + timeout) == .timedOut {
+            process.terminate()   // SIGTERM；claude 正常会随之关 stdout 解开后台读线程。
+            return nil            // 已降级返回，UI 不受影响（极端下后台读线程可能多挂一会，影响有界）
+        }
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+        return SessionScanner.parseLiveSessionIds(data)
+    }
+
+    /// 纯解析（可单测）：从 `claude agents --json` 输出抽 sessionId 集合。解析失败返 nil（降级）。
+    static func parseLiveSessionIds(_ data: Data) -> Set<String>? {
+        guard let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return nil }
+        var ids = Set<String>()
+        for obj in arr {
+            if let sid = obj["sessionId"] as? String, !sid.isEmpty { ids.insert(sid) }
+        }
+        return ids
+    }
+
+    /// 纯判定（可单测）：给定 job 的 sessionId + live 集合（nil=探测不可用），判存活安全性。
+    static func jobLiveness(sessionId: String, liveSessionIds: Set<String>?) -> JobLiveness {
+        guard let live = liveSessionIds else { return .unknown }
+        if sessionId.isEmpty { return .unknown }   // state.json 缺 sessionId → 无从对照
+        return live.contains(sessionId) ? .live : .dead
+    }
+
     // MARK: - Session List Scanning
 
     func scanSessionsInBackground(completion: @escaping () -> Void) {
@@ -98,6 +191,7 @@ final class SessionScanner {
                 return
             }
             self.scanActiveSessions()
+            self.scanFailedJobs()
 
             let scriptPath = FileManager.default.homeDirectoryForCurrentUser
                 .appendingPathComponent(".claude/自动化/scripts/scan-sessions.py").path

--- a/menubar/SessionScanner.swift
+++ b/menubar/SessionScanner.swift
@@ -179,12 +179,13 @@ final class SessionScanner {
 
     /// 停用一个仍在运行的 bg session（live failed job）：`claude stop <短id>`。
     ///
-    /// 实测 v2.1.154 行为（throwaway session 验过）：停后进程真死、离开 agents 列表、
-    /// state.json 变 "stopped"（→ 自动掉出 state=="failed" 红条）、对话保留可 `claude attach` 恢复。
-    /// daemon-aware（不像裸 kill <pid> 会被 claim-spare 复活）。**接受短 id（= jobId）**，不是完整 UUID。
+    /// 实测 v2.1.154 行为（throwaway bg-fleet session 验过）：停后进程真死、零孤儿、离开 agents 列表、
+    /// transcript + job 目录都在、state.json 变 "done"/"stopped"（**都 ≠ failed → 自动掉出红条**）、
+    /// 对话保留可 `claude attach` 恢复。daemon-aware（不像裸 kill <pid> 会被 claim-spare 复活、删目录会留孤儿）。
+    /// **接受短 id（= jobId，8 位前缀）**，不是完整 UUID（实测完整 UUID 报 "No job matching"）。
     ///
-    /// 返回 true = 确认停用成功（退出码 0 **且** 该 sessionId 已离开 `claude agents --json`）。
-    /// 双重判成功：退出码可靠（成功 0 / 无匹配 1），再用 agents 复查兜底，避免假装停了。
+    /// 返回 true = 确认停用成功（退出码 0 **且** sessionId 已掉出 `claude agents --json`）。
+    /// 退出码会骗人（no-match 也返 0），所以 agents 回查必须保留；但回查要 poll（掉出非瞬时，见下）。
     func stopAgentSession(jobId: String, sessionId: String, timeout: TimeInterval = 8.0) -> Bool {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
@@ -203,10 +204,19 @@ final class SessionScanner {
         }
         guard process.terminationStatus == 0 else { return false }
 
-        // 兜底复查：sessionId 不应再出现在 live 列表（非空时才查；空 sessionId 只能信退出码）
-        if sessionId.isEmpty { return true }
-        if let live = liveAgentSessionIds() { return !live.contains(sessionId) }
-        return true   // 复查不可用（probe nil）→ 退出码已 0，信它
+        // 兜底复查：sessionId 不应再出现在 live 列表（退出码会骗人——no-match 也返 0，所以这道回查必须保留）。
+        if sessionId.isEmpty { return true }   // 无 sessionId 可对照，只能信退出码
+
+        // ⚠️ 回查不能立刻做：主会话实测 `claude stop` ~0.2s 返回，但 session ~1s 后才掉出
+        // `claude agents --json`（非瞬时）。立刻查会看到它还在 → 误判 stop 失败。
+        // 改 poll：隔 ~0.7s 查一次，最多 ~5s，掉出即判成功；超时仍在才算真失败。
+        let deadline = Date().addingTimeInterval(5.0)
+        repeat {
+            Thread.sleep(forTimeInterval: 0.7)
+            guard let live = liveAgentSessionIds() else { return true }   // 复查不可用（probe nil）→ 退出码已 0，信它
+            if !live.contains(sessionId) { return true }                  // 已掉出 live 列表 = 确认停了
+        } while Date() < deadline
+        return false   // 超 ~5s 仍在 agents 列表 = 真失败
     }
 
     // MARK: - Session List Scanning

--- a/menubar/SessionScanner.swift
+++ b/menubar/SessionScanner.swift
@@ -177,6 +177,38 @@ final class SessionScanner {
         return live.contains(sessionId) ? .live : .dead
     }
 
+    /// 停用一个仍在运行的 bg session（live failed job）：`claude stop <短id>`。
+    ///
+    /// 实测 v2.1.154 行为（throwaway session 验过）：停后进程真死、离开 agents 列表、
+    /// state.json 变 "stopped"（→ 自动掉出 state=="failed" 红条）、对话保留可 `claude attach` 恢复。
+    /// daemon-aware（不像裸 kill <pid> 会被 claim-spare 复活）。**接受短 id（= jobId）**，不是完整 UUID。
+    ///
+    /// 返回 true = 确认停用成功（退出码 0 **且** 该 sessionId 已离开 `claude agents --json`）。
+    /// 双重判成功：退出码可靠（成功 0 / 无匹配 1），再用 agents 复查兜底，避免假装停了。
+    func stopAgentSession(jobId: String, sessionId: String, timeout: TimeInterval = 8.0) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["claude", "stop", jobId]
+        process.environment = augmentedEnvironment()
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do { try process.run() } catch { return false }
+
+        let group = DispatchGroup()
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async { process.waitUntilExit(); group.leave() }
+        if group.wait(timeout: .now() + timeout) == .timedOut {
+            process.terminate()
+            return false   // 超时不假装停了
+        }
+        guard process.terminationStatus == 0 else { return false }
+
+        // 兜底复查：sessionId 不应再出现在 live 列表（非空时才查；空 sessionId 只能信退出码）
+        if sessionId.isEmpty { return true }
+        if let live = liveAgentSessionIds() { return !live.contains(sessionId) }
+        return true   // 复查不可用（probe nil）→ 退出码已 0，信它
+    }
+
     // MARK: - Session List Scanning
 
     func scanSessionsInBackground(completion: @escaping () -> Void) {


### PR DESCRIPTION
> 关联 issue：LinekForge/forge-launcher #11（feat 主体）、#12（[design] bg-session 足迹不死归并 · oracle 方向）。

## 为什么
launcher 看不到、也清不掉 daemon background job 的僵死态。一条 daemon session 撞上不可恢复的 API error（实测如 `400 ... thinking block cannot be modified`）后，daemon 会用残缺历史反复 `--resume` 形成死循环，job 的 `state` 卡在 `"failed"`，用户只能手动翻 `~/.claude/jobs/` 删目录。launcher 此前完全不读 `jobs/`（见 #11）。

## 改了什么
1. **检测**（`SessionScanner.scanFailedJobs`）：扫 `~/.claude/jobs/<id>/state.json`，只收 `state=="failed"` 的 job（捕获 jobId / dir / name / detail / sessionId），随既有周期扫描一起跑。
2. **入口**（`PopoverController`）：`failedJobCount>0` 时显示红色第二警告条「🪦 N 个僵死任务 — 点击清理」，镜像既有「stale 会话」警告条的模式。
3. **只读存活探测 probe**（对齐 #12 oracle 方向）：送葬前跑一次 `claude agents --json`，cross-check 每个 failed job 的 `sessionId` 是否仍在 live 列表 →
   - 在 → ⚠ 进程仍在运行（删目录只留孤儿）
   - 不在 → ✓ 残留可清
   - 探测不可用 → 降级回静态范围边界文案
   - `SessionScanner.liveAgentSessionIds()`：`/usr/bin/env claude agents --json` + PATH 增强，3s 超时；spawn 失败 / 超时 / 非零退出 / 解析错一律返 `nil`。
   - 纯函数 `parseLiveSessionIds` / `jobLiveness` 拆出可单测。
4. **送葬**（`AppDelegate.purgeFailedJobs`）：probe 放后台跑（不冻结 UI）→ 主线程**双重确认**（两道默认按钮都是「取消」）+ 按存活逐条标注 → `FileManager.removeItem` 删 `jobs/<id>/` → rescan。

**三条护栏**：① 优雅降级——probe 任何失败返 `nil`，删除动作**绝不被 probe 阻塞**，`nil` 当「未知」而非「无 live session」。② fixture 测匹配/降级各分支。③ 最小只读——launcher 第一处 `claude agents` 依赖，只读、只在送葬前用一次，不进周期扫描、不扩散成全局 liveness 改造。

## 没改什么
- **不终止进程**：只删 `jobs/<id>/` **目录残留**。一个 bg session 的完整足迹还含 bg-spare 进程 / MCP server / `sessions/<pid>.json`，daemon 的 auto-adopt/claim-spare 可能从其他片段维持或复活。**完整 teardown（确认进程真死 + 释放）属 #12 §B oracle 线，是产品决定，不在本 PR**。对话框 / README / 注释均标明「删目录 ≠ 停进程，彻底终止用 `claude agents`」。
- **predicate 只匹配 `state=="failed"`**：实测 v2.1.154 的 state 词表含 `done`/`blocked`/`failed`，**`blocked` 是 bg session 等输入的存活态**（误删 = 干掉活 session 足迹），连同 `done`/运行中一并排除。
- 不并入 #11 part 1「可选显示 sdk-cli 入口 session」（产品/UI 选择）；不删 transcript（缩小破坏面）。

## 怎么验
- `swiftc -typecheck` 全 menubar 文件：EXIT=0。
- fixture（Swift，离线）：`scanFailedJobs` predicate（failed/blocked/done/running/malformed/无state）只 `job-failed` 被检出、`blocked` 目录原封不动、`removeItem` 正确删；probe `parseLiveSessionIds` + `jobLiveness` 全分支含 `nil` 降级与空 sessionId。
- live 烟测：`/usr/bin/env claude agents --json` 从 Swift `Process` 跑通，解析出真实 live sessionId。
- 字段映射已实测：`state.json.sessionId`（完整 UUID）↔ `claude agents --json` 的 `sessionId` 精确对齐；且 state 会滞后真实存活（`done` 的 job 进程可能仍 busy）→ agents 列表才是权威 liveness 信号。
- ⚠️ UI 交互（NSAlert / 红条 / 后台 probe）需 build 后人工点验，未在 CI/离线环境跑。

## 待议项（请 reviewer 拍板，未自决）
`state==failed` 的 job，其 `sessionId` 还会不会出现在 live `claude agents --json` 列表里？本机无 `failed` 样本，**无法验证实际命中率**。当前防御式实现（probe + 降级）保证：即便该 cross-check 永远命中「不在 live」，行为也无害（只是 probe 不产生额外价值，退化为静态提示）；真有 `failed` 样本时再证实 probe 的实际价值。是否接受这个「先防御、后证实」的取舍，请定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
