### PR TITLE
feat: add iTerm2 terminal support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -61,7 +61,9 @@ open "$MENU_APP"
 echo ""
 if [ -d "/Applications/Ghostty.app" ]; then
     echo "💡 终端：检测到 Ghostty，启动后自动使用 Ghostty。"
+elif [ -d "/Applications/iTerm.app" ]; then
+    echo "💡 终端：检测到 iTerm2，启动后自动使用 iTerm2。"
 else
-    echo "💡 终端：使用 Terminal.app。推荐装 Ghostty (https://ghostty.org) 获得更好体验。"
-    echo "   装了 Ghostty 后，退出菜单栏再重新打开即可自动切换。"
+    echo "💡 终端：使用 Terminal.app。推荐装 Ghostty (https://ghostty.org) 或 iTerm2 获得更好体验。"
+    echo "   装了新终端后，退出菜单栏再重新打开即可自动切换。"
 fi

--- a/menubar/TerminalAdapter.swift
+++ b/menubar/TerminalAdapter.swift
@@ -65,6 +65,13 @@ final class DynamicTerminal: TerminalAdapter {
             }
             return GhosttyTerminal()
         }
+        if apps.contains(where: { $0.bundleIdentifier == "com.googlecode.iterm2" }) {
+            if lastType != "iterm2" {
+                lastType = "iterm2"
+                os_log("Terminal: → iTerm2", log: log, type: .info)
+            }
+            return ITerm2Terminal()
+        }
         if lastType != "terminal" {
             lastType = "terminal"
             os_log("Terminal: → Terminal.app", log: log, type: .info)
@@ -167,5 +174,48 @@ final class AppleTerminal: TerminalAdapter {
         return false
         """
         return runAppleScript(script, label: "Terminal.app focus")?.booleanValue ?? false
+    }
+}
+
+// MARK: - iTerm2 Implementation
+
+final class ITerm2Terminal: TerminalAdapter {
+
+    func openTerminal(_ command: String) {
+        let escaped = escapeForAppleScript(command)
+        let script = """
+        tell application "iTerm"
+            activate
+            set newWindow to (create window with default profile)
+            tell current session of newWindow
+                write text "\(escaped)"
+            end tell
+        end tell
+        """
+        runAppleScript(script, label: "iTerm2 openTerminal")
+    }
+
+    func focusTerminalWindow(forPID pid: Int) -> Bool {
+        guard let ttyName = ttyForPID(pid) else { return false }
+
+        let fullTTY = "/dev/\(ttyName)"
+        let script = """
+        tell application "iTerm"
+            repeat with w in windows
+                repeat with t in tabs of w
+                    repeat with s in sessions of t
+                        if tty of s is "\(fullTTY)" then
+                            select s
+                            set index of w to 1
+                            activate
+                            return true
+                        end if
+                    end repeat
+                end repeat
+            end repeat
+        end tell
+        return false
+        """
+        return runAppleScript(script, label: "iTerm2 focus")?.booleanValue ?? false
     }
 }


### PR DESCRIPTION
## Summary

Add iTerm2 as a supported terminal emulator, expanding the terminal auto-detection chain.

### Changes

- **`TerminalAdapter.swift`** — New `ITerm2Terminal` class (~40 lines):
  - `openTerminal`: creates a new iTerm2 window via AppleScript and runs the command
  - `focusTerminalWindow`: matches PID → TTY → iTerm2 session, then focuses the corresponding window/tab
- **`TerminalAdapter.swift`** — `DynamicTerminal.current()` updated detection priority:
  - **Ghostty** (running) → **iTerm2** (running) → **Terminal.app** (fallback)
- **`build.sh`** — Terminal prompt message updated to mention iTerm2

### Testing

- ✅ Compiled successfully on macOS (arm64, macOS 13+)
- ✅ iTerm2 AppleScript API verified (`tty of every session` returns active TTYs)
- ✅ Bundle identifier confirmed: `com.googlecode.iterm2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)